### PR TITLE
Added global auto join group settings + removed some inconsistencies

### DIFF
--- a/src/main/java/de/maxhenkel/enhancedgroups/EnhancedGroupPermissionManager.java
+++ b/src/main/java/de/maxhenkel/enhancedgroups/EnhancedGroupPermissionManager.java
@@ -13,6 +13,7 @@ import java.util.List;
 public class EnhancedGroupPermissionManager implements PermissionManager<CommandSourceStack> {
 
     private final Permission AUTO_JOIN_GROUP_PERMISSION;
+    private final Permission AUTO_JOIN_GROUP_GLOBAL_PERMISSION;
     private final Permission FORCE_JOIN_GROUP_PERMISSION;
     private final Permission INSTANT_GROUP_PERMISSION;
     private final Permission PERSISTENT_GROUP_PERMISSION;
@@ -21,12 +22,14 @@ public class EnhancedGroupPermissionManager implements PermissionManager<Command
 
     public EnhancedGroupPermissionManager() {
         AUTO_JOIN_GROUP_PERMISSION = new Permission("enhancedgroups.autojoingroup", EnhancedGroups.CONFIG.autoJoinGroupCommandPermissionType.get());
+        AUTO_JOIN_GROUP_GLOBAL_PERMISSION = new Permission("enhancedgroups.autojoingroup.global", EnhancedGroups.CONFIG.autoJoinGroupGlobalCommandPermissionType.get());
         FORCE_JOIN_GROUP_PERMISSION = new Permission("enhancedgroups.forcejoingroup", EnhancedGroups.CONFIG.forceJoinGroupCommandPermissionType.get());
         INSTANT_GROUP_PERMISSION = new Permission("enhancedgroups.instantgroup", EnhancedGroups.CONFIG.instantGroupCommandPermissionType.get());
         PERSISTENT_GROUP_PERMISSION = new Permission("enhancedgroups.persistentgroup", EnhancedGroups.CONFIG.persistentGroupCommandPermissionType.get());
 
         PERMISSIONS = List.of(
                 AUTO_JOIN_GROUP_PERMISSION,
+                AUTO_JOIN_GROUP_GLOBAL_PERMISSION,
                 FORCE_JOIN_GROUP_PERMISSION,
                 INSTANT_GROUP_PERMISSION,
                 PERSISTENT_GROUP_PERMISSION
@@ -84,15 +87,11 @@ public class EnhancedGroupPermissionManager implements PermissionManager<Command
                 return false;
             }
             TriState permissionValue = Permissions.getPermissionValue(player, permission);
-            switch (permissionValue) {
-                case DEFAULT:
-                    return type.hasPermission(player);
-                case TRUE:
-                    return true;
-                case FALSE:
-                default:
-                    return false;
-            }
+            return switch (permissionValue) {
+                case DEFAULT -> type.hasPermission(player);
+                case TRUE -> true;
+                default -> false;
+            };
         }
 
         public PermissionType getType() {
@@ -100,7 +99,7 @@ public class EnhancedGroupPermissionManager implements PermissionManager<Command
         }
     }
 
-    public static enum PermissionType {
+    public enum PermissionType {
 
         EVERYONE, NOONE, OPS;
 

--- a/src/main/java/de/maxhenkel/enhancedgroups/EnhancedGroups.java
+++ b/src/main/java/de/maxhenkel/enhancedgroups/EnhancedGroups.java
@@ -35,18 +35,17 @@ public class EnhancedGroups implements ModInitializer {
         AUTO_JOIN_GROUP_STORE = new AutoJoinGroupStore(configFolder.resolve("auto-join-groups.json").toFile());
         PERMISSION_MANAGER = new EnhancedGroupPermissionManager();
 
-        CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> {
-            MinecraftAdmiral.builder(dispatcher, registryAccess)
-                    .addCommandClasses(
-                            AutoJoinGroupCommands.class,
-                            ForceJoinCommands.class,
-                            InstantGroupCommands.class,
-                            PersistentGroupCommands.class
-                    )
-                    .setPermissionManager(PERMISSION_MANAGER)
-                    .addArgumentTypes(argumentTypeRegistry -> argumentTypeRegistry.register(Group.Type.class, new GroupTypeArgumentSupplier(), new GroupTypeArgumentTypeSupplier()))
-                    .build();
-        });
+        CommandRegistrationCallback.EVENT.register((dispatcher, registryAccess, environment) -> MinecraftAdmiral.builder(dispatcher, registryAccess)
+                .addCommandClasses(
+                        AutoJoinGroupCommands.class,
+                        AutoJoinGroupGlobalCommands.class,
+                        ForceJoinCommands.class,
+                        InstantGroupCommands.class,
+                        PersistentGroupCommands.class
+                )
+                .setPermissionManager(PERMISSION_MANAGER)
+                .addArgumentTypes(argumentTypeRegistry -> argumentTypeRegistry.register(Group.Type.class, new GroupTypeArgumentSupplier(), new GroupTypeArgumentTypeSupplier()))
+                .build());
         GroupSummaryEvents.init();
     }
 }

--- a/src/main/java/de/maxhenkel/enhancedgroups/command/AutoJoinGroupCommands.java
+++ b/src/main/java/de/maxhenkel/enhancedgroups/command/AutoJoinGroupCommands.java
@@ -46,10 +46,6 @@ public class AutoJoinGroupCommands {
     }
 
     public static int autoJoin(CommandContext<CommandSourceStack> context, UUID groupId, @Nullable String password) throws CommandSyntaxException {
-        if (EnhancedGroups.AUTO_JOIN_GROUP_STORE.getGlobalGroupForced()) {
-            context.getSource().sendFailure(Component.literal("Global auto join is enforced on this server"));
-            return 0;
-        }
 
         ServerPlayer player = context.getSource().getPlayerOrException();
 
@@ -66,6 +62,9 @@ public class AutoJoinGroupCommands {
 
         EnhancedGroups.AUTO_JOIN_GROUP_STORE.setPlayerGroup(player.getUUID(), group.getId());
         context.getSource().sendSuccess(() -> Component.literal("You will now automatically connect to group '%s' when joining".formatted(group.getName())), false);
+        if (EnhancedGroups.AUTO_JOIN_GROUP_STORE.getGlobalGroupForced()) {
+            context.getSource().sendSystemMessage(Component.literal("Note: Global auto join is currently enforced, meaning that your custom auto join won't have any effect"));
+        }
         return 1;
     }
 }

--- a/src/main/java/de/maxhenkel/enhancedgroups/command/AutoJoinGroupCommands.java
+++ b/src/main/java/de/maxhenkel/enhancedgroups/command/AutoJoinGroupCommands.java
@@ -13,7 +13,6 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 
 import javax.annotation.Nullable;
-import java.util.Optional;
 import java.util.UUID;
 
 @RequiresPermission("enhancedgroups.autojoingroup")
@@ -24,12 +23,12 @@ public class AutoJoinGroupCommands {
 
     @Command("set")
     public int set(CommandContext<CommandSourceStack> context, @Name("group_name") String groupName, @OptionalArgument @Name("password") String password) throws CommandSyntaxException {
-        Optional<PersistentGroup> optionalPersistentGroup = EnhancedGroups.PERSISTENT_GROUP_STORE.getGroups().stream().filter(g -> g.getName().trim().equals(groupName.trim())).findFirst();
-        if (optionalPersistentGroup.isEmpty()) {
+        PersistentGroup persistentGroup = EnhancedGroups.PERSISTENT_GROUP_STORE.getGroup(groupName);
+        if (persistentGroup == null) {
             context.getSource().sendFailure(Component.literal("Group not found or not persistent"));
             return 0;
         }
-        return autoJoin(context, optionalPersistentGroup.get().getId(), password);
+        return autoJoin(context, persistentGroup.getId(), password);
     }
 
     // This method always needs to be after the String group name one, so it has priority to be processed properly
@@ -47,10 +46,14 @@ public class AutoJoinGroupCommands {
     }
 
     public static int autoJoin(CommandContext<CommandSourceStack> context, UUID groupId, @Nullable String password) throws CommandSyntaxException {
+        if (EnhancedGroups.AUTO_JOIN_GROUP_STORE.getGlobalGroupForced()) {
+            context.getSource().sendFailure(Component.literal("Global auto join is enforced on this server"));
+            return 0;
+        }
+
         ServerPlayer player = context.getSource().getPlayerOrException();
 
         PersistentGroup group = EnhancedGroups.PERSISTENT_GROUP_STORE.getGroup(groupId);
-
         if (group == null) {
             context.getSource().sendFailure(Component.literal("Group not found or not persistent"));
             return 0;
@@ -65,5 +68,4 @@ public class AutoJoinGroupCommands {
         context.getSource().sendSuccess(() -> Component.literal("You will now automatically connect to group '%s' when joining".formatted(group.getName())), false);
         return 1;
     }
-
 }

--- a/src/main/java/de/maxhenkel/enhancedgroups/command/AutoJoinGroupGlobalCommands.java
+++ b/src/main/java/de/maxhenkel/enhancedgroups/command/AutoJoinGroupGlobalCommands.java
@@ -1,0 +1,68 @@
+package de.maxhenkel.enhancedgroups.command;
+
+import com.mojang.brigadier.context.CommandContext;
+import de.maxhenkel.admiral.annotations.Command;
+import de.maxhenkel.admiral.annotations.Name;
+import de.maxhenkel.admiral.annotations.RequiresPermission;
+import de.maxhenkel.enhancedgroups.EnhancedGroups;
+import de.maxhenkel.enhancedgroups.config.PersistentGroup;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.network.chat.Component;
+
+import java.util.UUID;
+
+@RequiresPermission("enhancedgroups.autojoingroup.global")
+@Command({AutoJoinGroupCommands.AUTOJOINGROUP_COMMAND, "global"})
+public class AutoJoinGroupGlobalCommands {
+
+    @Command("set")
+    public int set(CommandContext<CommandSourceStack> context, @Name("group_name") String groupName) {
+        PersistentGroup persistentGroup = EnhancedGroups.PERSISTENT_GROUP_STORE.getGroup(groupName);
+        if (persistentGroup == null) {
+            context.getSource().sendFailure(Component.literal("Group not found or not persistent"));
+            return 0;
+        }
+        return autoJoin(context, persistentGroup.getId());
+    }
+
+    // This method always needs to be after the String group name one, so it has priority to be processed properly
+    @Command("set")
+    public int set(CommandContext<CommandSourceStack> context, @Name("id") UUID groupId) {
+        return autoJoin(context, groupId);
+    }
+
+    @Command("remove")
+    public int remove(CommandContext<CommandSourceStack> context) {
+        EnhancedGroups.AUTO_JOIN_GROUP_STORE.removeGlobalGroup();
+        context.getSource().sendSuccess(() -> Component.literal("Global auto join successfully removed"), false);
+        return 1;
+    }
+
+    @Command("force")
+    public int setForce(CommandContext<CommandSourceStack> context, @Name("status") boolean status) {
+        EnhancedGroups.AUTO_JOIN_GROUP_STORE.setGlobalGroupForced(status);
+        if (status) {
+            context.getSource().sendSuccess(() -> Component.literal("Global auto join is enforced from now on"), false);
+        } else {
+            context.getSource().sendSuccess(() -> Component.literal("Global auto join is not enforced anymore"), false);
+        }
+        return 1;
+    }
+
+    public static int autoJoin(CommandContext<CommandSourceStack> context, UUID groupId) {
+        PersistentGroup group = EnhancedGroups.PERSISTENT_GROUP_STORE.getGroup(groupId);
+        if (group == null) {
+            context.getSource().sendFailure(Component.literal("Group not found or not persistent"));
+            return 0;
+        }
+
+        if (group.getPassword() != null) {
+            context.getSource().sendFailure(Component.literal("Global auto join groups can't be password-protected"));
+            return 0;
+        }
+
+        EnhancedGroups.AUTO_JOIN_GROUP_STORE.setGlobalGroup(group.getId());
+        context.getSource().sendSuccess(() -> Component.literal("Everyone will now automatically connect to group '%s' when joining".formatted(group.getName())), false);
+        return 1;
+    }
+}

--- a/src/main/java/de/maxhenkel/enhancedgroups/config/AutoJoinGroupStore.java
+++ b/src/main/java/de/maxhenkel/enhancedgroups/config/AutoJoinGroupStore.java
@@ -2,49 +2,44 @@ package de.maxhenkel.enhancedgroups.config;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.reflect.TypeToken;
 import de.maxhenkel.enhancedgroups.EnhancedGroups;
 
 import javax.annotation.Nullable;
 import java.io.*;
-import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
 public class AutoJoinGroupStore {
-
     private final File file;
     private final Gson gson;
-    private Map<UUID, UUID> playerGroups;
-
+    private StoreContent content;
     public AutoJoinGroupStore(File file) {
         this.file = file;
-        this.gson = new GsonBuilder().create();
-        this.playerGroups = new HashMap<>();
+        this.gson = new GsonBuilder().setPrettyPrinting().create();
+        this.content = new StoreContent();
         load();
     }
 
     public void load() {
         if (!file.exists()) {
+            EnhancedGroups.LOGGER.error("Failed to load auto join groups");
             return;
         }
         try (Reader reader = new FileReader(file)) {
-            Type playerGroupsType = new TypeToken<Map<UUID, UUID>>() {
-            }.getType();
-            playerGroups = gson.fromJson(reader, playerGroupsType);
+            content = gson.fromJson(reader, StoreContent.class);
         } catch (Exception e) {
-            EnhancedGroups.LOGGER.error("Failed to load auto join groups", e);
+            EnhancedGroups.LOGGER.error("Failed to parse auto join groups", e);
         }
-        if (playerGroups == null) {
-            playerGroups = new HashMap<>();
+        if (content == null) {
+            content = new StoreContent();
         }
     }
 
     public void save() {
         file.getParentFile().mkdirs();
         try (Writer writer = new FileWriter(file)) {
-            gson.toJson(playerGroups, writer);
+            gson.toJson(content, writer);
         } catch (Exception e) {
             EnhancedGroups.LOGGER.error("Failed to save auto join groups", e);
         }
@@ -52,17 +47,52 @@ public class AutoJoinGroupStore {
 
     @Nullable
     public UUID getPlayerGroup(UUID playerUuid) {
-        return playerGroups.get(playerUuid);
+        return content.playerGroups.get(playerUuid);
     }
 
     public void setPlayerGroup(UUID playerUuid, UUID groupId) {
-        playerGroups.put(playerUuid, groupId);
+        content.playerGroups.put(playerUuid, groupId);
         save();
     }
 
     public void removePlayerGroup(UUID playerUuid) {
-        playerGroups.remove(playerUuid);
+        content.playerGroups.remove(playerUuid);
         save();
     }
 
+    @Nullable
+    public UUID getGlobalGroup() {
+        return content.globalGroup;
+    }
+
+    public void setGlobalGroup(UUID groupId) {
+        content.globalGroup = groupId;
+        save();
+    }
+
+    public void removeGlobalGroup() {
+        content.globalGroup = null;
+        save();
+    }
+
+    public boolean getGlobalGroupForced() {
+        return content.globalGroupForced;
+    }
+
+    public void setGlobalGroupForced(boolean status) {
+        content.globalGroupForced = status;
+        save();
+    }
+
+    private static class StoreContent {
+        public Map<UUID, UUID> playerGroups;
+        public UUID globalGroup;
+        public boolean globalGroupForced;
+
+        StoreContent() {
+            playerGroups = new HashMap<>();
+            globalGroup = null;
+            globalGroupForced = false;
+        }
+    }
 }

--- a/src/main/java/de/maxhenkel/enhancedgroups/config/CommonConfig.java
+++ b/src/main/java/de/maxhenkel/enhancedgroups/config/CommonConfig.java
@@ -11,6 +11,7 @@ public class CommonConfig {
     public final ConfigEntry<EnhancedGroupPermissionManager.PermissionType> instantGroupCommandPermissionType;
     public final ConfigEntry<EnhancedGroupPermissionManager.PermissionType> persistentGroupCommandPermissionType;
     public final ConfigEntry<EnhancedGroupPermissionManager.PermissionType> autoJoinGroupCommandPermissionType;
+    public final ConfigEntry<EnhancedGroupPermissionManager.PermissionType> autoJoinGroupGlobalCommandPermissionType;
     public final ConfigEntry<EnhancedGroupPermissionManager.PermissionType> forceJoinGroupCommandPermissionType;
     public final ConfigEntry<Boolean> groupSummary;
     public final ConfigEntry<ForcedGroupType> forceGroupType;
@@ -18,29 +19,57 @@ public class CommonConfig {
     public CommonConfig(ConfigBuilder builder) {
         defaultInstantGroupRange = builder
                 .doubleEntry("default_instant_group_range", 128D, 1D, Double.MAX_VALUE)
-                .comment("The default range for the instant group command if no range was provided");
+                .comment("The default range for the /instantgroup command if no range was provided");
         instantGroupName = builder
                 .stringEntry("instant_group_name", "Instant Group")
                 .comment("The name of the instant group");
         instantGroupCommandPermissionType = builder
                 .enumEntry("instant_group_command_permission_level", EnhancedGroupPermissionManager.PermissionType.EVERYONE)
-                .comment("The default permission type of the instantgroup command");
+                .comment(
+                        "The default permission level of the /instantgroup command",
+                        "EVERYONE - Every player can use this command",
+                        "OPS - Operators can use this command",
+                        "NOONE - The command can't be used by anyone"
+                );
         persistentGroupCommandPermissionType = builder
                 .enumEntry("persistent_group_command_permission_level", EnhancedGroupPermissionManager.PermissionType.OPS)
-                .comment("The default permission type of the persistentgroup command");
+                .comment(
+                        "The default permission level of the /persistentgroup command",
+                        "EVERYONE - Every player can use this command",
+                        "OPS - Operators can use this command",
+                        "NOONE - The command can't be used by anyone"
+                );
         autoJoinGroupCommandPermissionType = builder
                 .enumEntry("auto_join_group_command_permission_type", EnhancedGroupPermissionManager.PermissionType.EVERYONE)
-                .comment("The default permission type of the autojoingroup command");
+                .comment(
+                        "The default permission level of the /autojoingroup command",
+                        "EVERYONE - Every player can use this command",
+                        "OPS - Operators can use this command",
+                        "NOONE - The command can't be used by anyone"
+                );
+        autoJoinGroupGlobalCommandPermissionType = builder
+                .enumEntry("auto_join_group_global_command_permission_type", EnhancedGroupPermissionManager.PermissionType.OPS)
+                .comment(
+                        "The default permission level of the /autojoingroup global command",
+                        "EVERYONE - Every player can use this command",
+                        "OPS - Operators can use this command",
+                        "NOONE - The command can't be used by anyone"
+                );
         forceJoinGroupCommandPermissionType = builder
                 .enumEntry("force_join_group_command_permission_type", EnhancedGroupPermissionManager.PermissionType.OPS)
-                .comment("The default permission type of the forcejoingroup command");
+                .comment(
+                        "The default permission level of the /forcejoingroup command",
+                        "EVERYONE - Every player can use this command",
+                        "OPS - Operators can use this command",
+                        "NOONE - The command can't be used by anyone"
+                );
         groupSummary = builder
                 .booleanEntry("group_summary", true)
-                .comment("If a summary of all groups should be shown when a player joins the server");
+                .comment("Determines if a summary of all groups should be shown when a player joins the server");
         forceGroupType = builder
                 .enumEntry("force_group_type", ForcedGroupType.OFF)
                 .comment(
-                        "If the group type should be forced to a specific type",
+                        "Forces all groups to be of the given type",
                         "OFF - No group type is forced",
                         "NORMAL - All groups are forced to be normal groups",
                         "OPEN - All groups are forced to be open groups",

--- a/src/main/java/de/maxhenkel/enhancedgroups/config/PersistentGroupStore.java
+++ b/src/main/java/de/maxhenkel/enhancedgroups/config/PersistentGroupStore.java
@@ -19,7 +19,7 @@ public class PersistentGroupStore {
 
     public PersistentGroupStore(File file) {
         this.file = file;
-        this.gson = new GsonBuilder().create();
+        this.gson = new GsonBuilder().setPrettyPrinting().create();
         this.groups = new ArrayList<>();
         this.groupCache = new HashMap<>();
         load();
@@ -27,6 +27,7 @@ public class PersistentGroupStore {
 
     public void load() {
         if (!file.exists()) {
+            EnhancedGroups.LOGGER.error("Failed to load persistent groups");
             return;
         }
         try (Reader reader = new FileReader(file)) {
@@ -34,11 +35,12 @@ public class PersistentGroupStore {
             }.getType();
             groups = gson.fromJson(reader, groupListType);
         } catch (Exception e) {
-            EnhancedGroups.LOGGER.error("Failed to load persistent groups", e);
+            EnhancedGroups.LOGGER.error("Failed to parse persistent groups", e);
         }
         if (groups == null) {
             groups = new ArrayList<>();
         }
+
         for (PersistentGroup group : groups) {
             group.getId(); // This generates IDs for all groups that don't have one
         }

--- a/src/main/java/de/maxhenkel/enhancedgroups/events/AutoJoinGroupEvents.java
+++ b/src/main/java/de/maxhenkel/enhancedgroups/events/AutoJoinGroupEvents.java
@@ -11,16 +11,23 @@ public class AutoJoinGroupEvents {
 
     public static void onPlayerConnected(PlayerConnectedEvent event) {
         VoicechatConnection connection = event.getConnection();
-        UUID persistentGroupId = EnhancedGroups.AUTO_JOIN_GROUP_STORE.getPlayerGroup(connection.getPlayer().getUuid());
 
-        if (persistentGroupId == null) {
+        UUID playerGroupId = EnhancedGroups.AUTO_JOIN_GROUP_STORE.getPlayerGroup(connection.getPlayer().getUuid());
+        UUID globalGroupId = EnhancedGroups.AUTO_JOIN_GROUP_STORE.getGlobalGroup();
+        boolean globalGroupForced = EnhancedGroups.AUTO_JOIN_GROUP_STORE.getGlobalGroupForced();
+        UUID selectedGroupId;
+
+        if (!globalGroupForced && playerGroupId != null) {
+            selectedGroupId = playerGroupId;
+        } else if (globalGroupId != null) {
+            selectedGroupId = globalGroupId;
+        } else {
             return;
         }
 
-        UUID voicechatId = EnhancedGroups.PERSISTENT_GROUP_STORE.getVoicechatId(persistentGroupId);
+        UUID voicechatId = EnhancedGroups.PERSISTENT_GROUP_STORE.getVoicechatId(selectedGroupId);
 
         Group group = event.getVoicechat().getGroup(voicechatId);
-
         if (group == null) {
             return;
         }

--- a/src/main/java/de/maxhenkel/enhancedgroups/events/AutoJoinGroupEvents.java
+++ b/src/main/java/de/maxhenkel/enhancedgroups/events/AutoJoinGroupEvents.java
@@ -11,17 +11,19 @@ public class AutoJoinGroupEvents {
 
     public static void onPlayerConnected(PlayerConnectedEvent event) {
         VoicechatConnection connection = event.getConnection();
+        UUID playerId = connection.getPlayer().getUuid();
 
-        UUID playerGroupId = EnhancedGroups.AUTO_JOIN_GROUP_STORE.getPlayerGroup(connection.getPlayer().getUuid());
         UUID globalGroupId = EnhancedGroups.AUTO_JOIN_GROUP_STORE.getGlobalGroup();
         boolean globalGroupForced = EnhancedGroups.AUTO_JOIN_GROUP_STORE.getGlobalGroupForced();
         UUID selectedGroupId;
 
-        if (!globalGroupForced && playerGroupId != null) {
-            selectedGroupId = playerGroupId;
-        } else if (globalGroupId != null) {
+        if (globalGroupForced) {
             selectedGroupId = globalGroupId;
         } else {
+            UUID playerGroupId = EnhancedGroups.AUTO_JOIN_GROUP_STORE.getPlayerGroup(playerId);
+            selectedGroupId = (playerGroupId != null) ? playerGroupId : globalGroupId;
+        }
+        if (selectedGroupId == null) {
             return;
         }
 
@@ -31,7 +33,6 @@ public class AutoJoinGroupEvents {
         if (group == null) {
             return;
         }
-
         connection.setGroup(group);
     }
 }


### PR DESCRIPTION
(Closes #3)

This PR adds a new subcommand to `/autojoingroup` called `global`, which allows operators (by default) to set a default auto join group and even enforce it.
In practice, the command syntax looks like this:

```
/autojoingroup global set [<name>|<id>] (note: global auto join groups can't be password-protected)
/autojoingroup global remove
/autojoingroup global force [true|false]
```

I also reworked some minor things in the code, like fixing inconsistencies between using `null` checks and `Optional`s
or `AutoJoinGroupCommands` not using `PersistentGroupStore.getGroup()` even though it's doing the same thing.
